### PR TITLE
fix(parser): Don't read the body of a DELETE message

### DIFF
--- a/mocha_test.go
+++ b/mocha_test.go
@@ -402,3 +402,34 @@ func TestMocha_Silently(t *testing.T) {
 	assert.Equal(t, 201, res.StatusCode)
 	assert.Equal(t, string(body), "hello world")
 }
+
+func TestDelete(t *testing.T) {
+	m := New(t)
+	m.Start()
+
+	scoped := m.AddMocks(
+		Delete(expect.URLPath("/test")).
+			Header("test", expect.ToEqual("hello")).
+			Query("filter", expect.ToEqual("all")).
+			Reply(reply.
+				Created().
+				BodyString("deleted")))
+
+	req, _ := http.NewRequest(http.MethodDelete, m.URL()+"/test?filter=all", http.NoBody)
+	req.Header.Add("test", "hello")
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, scoped.Called())
+	assert.Equal(t, 201, res.StatusCode)
+	assert.Equal(t, string(body), "deleted")
+}

--- a/request_body_parser.go
+++ b/request_body_parser.go
@@ -25,7 +25,7 @@ type RequestBodyParser interface {
 // parseRequestBody tests given parsers until it finds one that can parse the request body.
 // User provided RequestBodyParser takes precedence.
 func parseRequestBody(r *http.Request, parsers []RequestBodyParser) (any, error) {
-	if r.Body != nil && r.Method != http.MethodGet && r.Method != http.MethodHead {
+	if r.Body != nil && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodDelete {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Generally DELETE messages are treated like GET messages with different connotations, so this prevents client library flags from interfering with matching.

## Summary

Generally DELETE messages are treated like GET messages with different connotations, so this prevents client library flags from interfering with matching.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows **[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)** standard
- [x] The code follows project code style standards
- [x] Tests have been added for this change

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] CI
- [ ] Documentation
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Does this PR add new third-party libraries? If yes, please explain why

- [ ] Yes
- [x] No
